### PR TITLE
Support message signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Installs/Configures Shibboleth Service Provider.
 * `node['shibboleth-sp']['attribute-map']['attributes']` - An array of hashs 
   with the name (required), id (required), and nameFormat (optional) of 
   attirbutes to map from the IdP.
+* `node['shibboleth-sp']['sign-messages']` - Whether to sign outgoing messages.
+Defaults to false.
 
 
 ### Web Server Specific Attributes

--- a/templates/default/shibboleth2.xml.erb
+++ b/templates/default/shibboleth2.xml.erb
@@ -99,7 +99,7 @@
 
 	<!-- The ApplicationDefaults element is where most of Shibboleth's SAML bits are defined. -->
 	<ApplicationDefaults entityID="<%= node['shibboleth-sp']['entityID'] %>"
-						 REMOTE_USER="<%= node['shibboleth-sp']['REMOTE_USER'] %>">
+            REMOTE_USER="<%= node['shibboleth-sp']['REMOTE_USER'] %>" signing="<%= node['shibboleth-sp']['sign-messages'] ? node['shibboleth-sp']['sign'] : "false" %>">
 
 		<!--
 		Controls session lifetimes, address checks, cookie handling, and the protocol handlers.


### PR DESCRIPTION
Adds an option controlling the "signing" attribute on the ApplicationDefaults configuration element of shibboleth2.xml, which must be "true" for some integration scenarios with Active Directory Federation Services 2.0 as IdP.
